### PR TITLE
[#31] Fix early ordeals flag not being used.

### DIFF
--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -81,6 +81,10 @@ namespace FF1Lib
 				ShuffleOrdeals(rng);
 			}
 
+      if (flags.EarlyOrdeals) {
+        EnableEarlyOrdeals();
+      }
+
 			if (flags.EarlyRod)
 			{
 				EnableEarlyRod();

--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -155,10 +155,12 @@ namespace FF1Lib
 		    const byte LostTeleportIndex = 0x3C;
 		    Put(TeleportOffset + LostTeleportIndex, new byte[] { 0x10 });
 		    Put(TeleportOffset + TeleportCount + LostTeleportIndex, new byte[] { 0x12 });
+	    }
 
-			// Remove CROWN requirement for Ordeals.
+    public void EnableEarlyOrdeals() {
+      // Remove CROWN requirement for Ordeals.
 			const int OrdealsTileset = 1;
-		    var ordealsTilesetOffset = TilesetDataOffset + OrdealsTileset * TilesetDataCount * TilesetDataSize;
+		  var ordealsTilesetOffset = TilesetDataOffset + OrdealsTileset * TilesetDataCount * TilesetDataSize;
 			var ordealsTilesetData = Get(ordealsTilesetOffset, TilesetDataCount * TilesetDataSize).ToUShorts();
 
 			// The 4 masked-out bits are special flags for a tile.  We wipe the flags for the two throne teleportation tiles,
@@ -168,7 +170,7 @@ namespace FF1Lib
 		    ordealsTilesetData[0x62] &= specialMask;
 
 			Put(ordealsTilesetOffset, Blob.FromUShorts(ordealsTilesetData));
-	    }
+    }
 
 		public List<Map> ReadMaps()
 	    {


### PR DESCRIPTION
The early-access to the Castle of Ordeals was, incorrectly, a part of the Shuffle Ordeals flag. As a result, the Early Ordeals convenience was useless, and one could always access the dungeon early if its teleporters were being shuffled.