### PR TITLE
Gain multiple levels at once added to speed hacks.

### DIFF
--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -86,6 +86,9 @@ namespace FF1Lib
 			Data[0x33CCD] = 0x04; // Explosion effect count (small enemies), default 8
 			Data[0x33DAA] = 0x04; // Explosion effect count (mixed enemies), default 15
 
+			//Gain multiple levels at once.  Also supresses stat increase messages as a side effect
+			Put(0x2DD82, Blob.FromHex("20579f48a5802907c907f008a58029f0690785806820019c4ce89b"));
+
 			// Default Response Rate 8 (0-based)
 			Data[0x384CB] = 0x07; // Initialize respondrate to 7
 			Put(0x3A153, Blob.FromHex("4CF0BF")); // Replace reset respond rate with a JMP to...


### PR DESCRIPTION
This patch allows multiple levels to be gained at the end of combat.  Due to the size of the new code required, part of the stat increase message display routine had to be overwritten and therefore this is patch also skips stat messages other than max HP.  Commented ASM source for the patch is as follows:
```
JSR $9F57 ;undraw all battle boxes
PHA ;maybe not needed
LDA $80 ;check if pointer to exp was changed
AND #$7
CMP #$7
BEQ LevelLoop
LDA $80 ;reset exp pointer
AND #$F0
ADC #$7
STA $80
LevelLoop:
PLA 
JSR $9C01 ;get exp to lvlup
JMP $9BE8
```