### PR TITLE
Fix EarlyOrders label click.

### DIFF
--- a/FF1RandomizerOnline/Views/Home/Randomize.cshtml
+++ b/FF1RandomizerOnline/Views/Home/Randomize.cshtml
@@ -74,7 +74,7 @@
 			<div class="col-xs-4">
 				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.EarlyRod" /> <label asp-for="Flags.EarlyRod">Early Rod</label></div>
 				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.EarlyCanoe" /> <label asp-for="Flags.EarlyCanoe">Early Canoe</label></div>
-				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.EarlyOrdeals" /> <label asp-for="Flags.EarlyRod">Early Ordeals</label></div>
+				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.EarlyOrdeals" /> <label asp-for="Flags.EarlyOrdeals">Early Ordeals</label></div>
 				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.EarlyBridge" /> <label asp-for="Flags.EarlyBridge">Early Bridge</label></div>
 				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.NoPartyShuffle" /> <label asp-for="Flags.NoPartyShuffle">No Party Shuffle</label></div>
 				<div class="checkbox-cell"><input type="checkbox" asp-for="Flags.SpeedHacks" /> <label asp-for="Flags.SpeedHacks">Speed Hacks</label></div>


### PR DESCRIPTION
It was triggering the EarlyRod box instead. Clicking the EarlyOrdeals
checkbox directly still worked so this is pretty minor.