### PR TITLE
ModernBattlefield V2.0 Bugfix.

### DIFF
--- a/FF1Lib/Fun.cs
+++ b/FF1Lib/Fun.cs
@@ -352,7 +352,7 @@ namespace FF1Lib
 			{
 				Data[0x31F85 + i * 2] = (byte)(xCoord - 0x10);            // X Coord of Character targeting cursor
 				Data[0x31F86 + i * 2] = (byte)(yCoord + 4 + (i * 0x1C));  // Y Coord of Character targeting cursor
-				Data[0x31F76 + i * 2] = (byte)(0xA7 + (i % 4 * 0x10));    // Y Coord of Command Menu cursor
+				Data[0x31F76 + i * 2] = (byte)(0xA7 + (Math.Min(i, 4) % 4 * 0x10)); // Y Coord of Command Menu cursor (last four are identical)
 			}
 
 			// Start backdrop rows two tiles left and one upward. This matches FF2/3


### PR DESCRIPTION
It would allow you to select the spaces below RUN. It still just
ran like the vanilla game but it was pretty ugly. Thanks to sbq92
for finding this one.