### PR TITLE
Allows warp to be used if in the last spell slot

### DIFF
--- a/FF1Lib/BugFixes.cs
+++ b/FF1Lib/BugFixes.cs
@@ -48,6 +48,11 @@ namespace FF1Lib
 			Put(0x323EF, new byte[] { 0x82 });
 		}
 
+		public void FixWarpBug()
+		{
+			Put(0x3AEF3, Blob.FromHex("187D0063")); // Allows last slot in a spell level to be used outside of battle
+		}
+
 		public void FixSpellBugs()
 		{
 			Put(0x33A4E, Blob.FromHex("F017EA")); // LOCK routine

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -126,6 +126,7 @@ namespace FF1Lib
 
 			if (flags.MagicLevels)
 			{
+				FixWarpBug(); // The warp bug only needs to be fixed if the magic levels are being shuffled
 				ShuffleMagicLevels(rng, flags.MagicPermissions);
 			}
 

--- a/FF1Lib/Magic.cs
+++ b/FF1Lib/Magic.cs
@@ -63,17 +63,7 @@ namespace FF1Lib
 			var blackSpells = magicSpells.Where((spell, i) => (i / 4) % 2 == 1).ToList();
 
 			whiteSpells.Shuffle(rng);
-
-			const int warpIndex = 38;
-			bool warpBug;
-			do
-			{
-				blackSpells.Shuffle(rng);
-				var newWarpIndex = blackSpells.FindIndex(spell => spell.Index == warpIndex);
-
-				// If WARP is the last spell in its level, it won't work due to a bug in the original game.
-				warpBug = newWarpIndex % 4 == 3;
-			} while (warpBug);
+			blackSpells.Shuffle(rng);
 
 			// Now we re-interleave the spells.
 			var shuffledSpells = new List<MagicSpell>();


### PR DESCRIPTION
Changes the the following:

    AND #$38               ;  this effectively makes A the spell level * 8
    ORA ch_spells, X       ; then ORA with the selected spell on this level
    CLC                    ; and add the spell start constant - 1 (-1 because 0 is not a spell)
    ADC #MG_START-1

to:

    AND #$38               ;  this effectively makes A the spell level * 8
    CLC
    ADC ch_spells, X       ; then ADC with the selected spell on this level  (this will never set the carry flag)
    ADC #MG_START-1      ; and add the spell start constant - 1 (-1 because 0 is not a spell)

the comment in the dissassembly describes this well:

                           ; BUGGED:  it just so happens that this code bug never occured in game because the spells
                           ;  were arranged in a way where it wouldn't be a problem.  HOWEVER.  The problem here lies
                           ;  in the fact that spells are 1-based and not zero based, and ORA is used instead of ADC
                           ; This means that the 8th spell on each spell level is 08 instead of 07.  Of course, 08 is
                           ;  also the start of the NEXT level of spells.
                           ; Example..... level 1 spells before this last ADC should be A=01-08.  and level 2 spells should
                           ;  be A=09-10.  Level 3 spells are A=11-18, and so on.  But consider SLOW, which is the 8th spell
                           ;  on level 2.  This spell will be listed as $08 in RAM on level 2.  now the above AND
                           ;  will result in A=08 for all level 2 spells... but when you ORA with SLOW's spell ID ($08)
                           ;  you still have $08!  not $10 like you should have (like what you'd get if you used ADC).
                           ; as a result... SLOW effectively has the same ID here as LIT.
                           ; But note that since the 8th spell on the level is always a black magic spell... and none
                           ; of them can be cast outside of battle, this bug never causes a problem.  