### PR TITLE
Puts enemy elemental resistances in ram and allows spells to affect it

### DIFF
--- a/FF1Lib/BugFixes.cs
+++ b/FF1Lib/BugFixes.cs
@@ -73,5 +73,18 @@ namespace FF1Lib
 		{
 			Put(0x32812, Blob.FromHex("DF")); // This is the craziest freaking patch ever, man.
 		}
+
+		public void FixEnemyElementalResistances()
+		{
+			// make XFER and other elemental resistance changing spells affect enemies
+			// Replace second copy of low bye for hp with elemental resistance
+			Put(0x32FE1, Blob.FromHex("13"));
+			// Switch to reading elemental resistance from ROM to RAM and make room for the extra byte
+			Put(0x3370A, Blob.FromHex("A012B1908D7768A009B1908D7E68B1928D7F68C8B1908D8568C8B1908D82684CFABB00000000"));
+			// add JSR to new routine for the extra room
+			Put(0x3378C, Blob.FromHex("20B5B6"));
+			// move 3 byes from previous subroutine and save elemental resistance of the enemy
+			Put(0x336B5, Blob.FromHex("C89190AD7768A01291906000000000000000")); // extra room at the end for new code
+		}
 	}
 }

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -228,6 +228,11 @@ namespace FF1Lib
 				FixEnemyStatusAttackBug();
 			}
 
+			if (flags.EnemyElementalResistancesBug)
+			{
+				FixEnemyElementalResistances();
+			}
+
 			if (flags.FunEnemyNames)
 			{
 				FunEnemyNames(flags.TeamSteak);

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -143,6 +143,9 @@ namespace FF1Lib
 		[FlagString(Character = 15, FlagBit = 16)]
 		public bool EnemyStatusAttackBug { get; set; }
 
+		[FlagString(Character = 21, FlagBit = 8)]
+		public bool EnemyElementalResistancesBug { get; set; }
+
 		public bool ModernBattlefield { get; set; }
 		public bool FunEnemyNames { get; set; }
 		public bool PaletteSwap { get; set; }

--- a/FF1RandomizerOnline/Controllers/HomeController.cs
+++ b/FF1RandomizerOnline/Controllers/HomeController.cs
@@ -121,6 +121,7 @@ namespace FF1RandomizerOnline.Controllers
 					ChanceToRun = true,
 					SpellBugs = true,
 					EnemyStatusAttackBug = true,
+					EnemyElementalResistancesBug = true,
 
 					FunEnemyNames = true,
 					PaletteSwap = true,

--- a/FF1RandomizerOnline/Views/Home/Randomize.cshtml
+++ b/FF1RandomizerOnline/Views/Home/Randomize.cshtml
@@ -224,6 +224,7 @@
 				<div class="checkbox-cell"><input v-model="ChanceToRun" type="checkbox" asp-for="Flags.ChanceToRun" /> <label asp-for="Flags.ChanceToRun">Chance to Run</label></div>
 				<div class="checkbox-cell"><input v-model="SpellBugs" type="checkbox" asp-for="Flags.SpellBugs" /> <label asp-for="Flags.SpellBugs">LOCK, LOK2, HEL2, TMPR, SABR</label></div>
 				<div class="checkbox-cell"><input v-model="EnemyStatusAttackBug" type="checkbox" asp-for="Flags.EnemyStatusAttackBug" /> <label asp-for="Flags.EnemyStatusAttackBug">Enemy Status Attacks</label></div>
+				<div class="checkbox-cell"><input v-model="EnemyElementalResistancesBug" type="checkbox" asp-for="Flags.EnemyElementalResistancesBug" /> <label asp-for="Flags.EnemyElementalResistancesBug">Enemy Elemental Resistances</label></div>
 			</div>
 		</div>
 		<div class="section tab-pane" id="fun">


### PR DESCRIPTION
This fixes spells like XFER which affect enemy elemental resistances since they are now stored in ram, this along with my enemy AoE spells PR will allow AFIR to work on the caster.

this solves #100